### PR TITLE
Add date filter persistence, Sankey diagram, and reorganize analytics…

### DIFF
--- a/backend/models/analytics_filters.py
+++ b/backend/models/analytics_filters.py
@@ -1,0 +1,28 @@
+# backend/models/analytics_filters.py
+from pydantic import BaseModel, Field
+from typing import Optional, Any, Dict
+from datetime import datetime
+
+class AnalyticsFiltersPreference(BaseModel):
+    """User's saved default analytics filter preferences"""
+    username: str
+    date_range: str = "all"
+    custom_start_date: Optional[str] = None
+    custom_end_date: Optional[str] = None
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+    class Config:
+        populate_by_name = True
+
+class FiltersUpdate(BaseModel):
+    """Request model for updating filter preferences"""
+    date_range: str = "all"
+    custom_start_date: Optional[str] = None
+    custom_end_date: Optional[str] = None
+
+class FiltersResponse(BaseModel):
+    """Response model for filter preferences"""
+    date_range: str
+    custom_start_date: Optional[str] = None
+    custom_end_date: Optional[str] = None
+    updated_at: Optional[datetime] = None

--- a/web/src/app/(protected)/page.tsx
+++ b/web/src/app/(protected)/page.tsx
@@ -19,9 +19,9 @@ export default function Home() {
         <Link href="/internships" className="focus-ring inline-flex items-center rounded-md bg-white/10 px-4 py-2 text-sm font-medium transition-colors hover:bg-white/15">
           Browse Internships
         </Link>
-        <button className="focus-ring inline-flex items-center rounded-md border border-default px-4 py-2 text-sm font-medium transition-colors hover:bg-white/5" disabled>
-          Analytics (soon)
-        </button>
+        <Link href="/analytics" className="focus-ring inline-flex items-center rounded-md bg-white/10 px-4 py-2 text-sm font-medium transition-colors hover:bg-white/15">
+          Analytics
+        </Link>
       </div>
     </section>
   );

--- a/web/src/components/analytics/FilterBar.tsx
+++ b/web/src/components/analytics/FilterBar.tsx
@@ -57,21 +57,37 @@ export default function FilterBar({ filters, onFiltersChange, companies, locatio
   };
 
   const handleSaveFilters = async () => {
-    // For now, just save to localStorage
-    // Backend endpoint can be added later if needed
     setIsSaving(true);
     setSaveMessage(null);
 
     try {
-      localStorage.setItem('analytics_filters', JSON.stringify({
-        dateRange: filters.dateRange,
-        customStartDate: filters.customStartDate,
-        customEndDate: filters.customEndDate,
-      }));
+      const token = localStorage.getItem('jwt_token');
+      if (!token) {
+        throw new Error('No authentication token');
+      }
+
+      // Save to backend
+      const res = await fetch(buildApiUrl('/analytics/filters'), {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          date_range: filters.dateRange,
+          custom_start_date: filters.customStartDate,
+          custom_end_date: filters.customEndDate,
+        }),
+      });
+
+      if (!res.ok) {
+        throw new Error('Failed to save filters to server');
+      }
 
       setSaveMessage('Filters saved successfully!');
       setTimeout(() => setSaveMessage(null), 3000);
     } catch (error) {
+      console.error('Failed to save filters:', error);
       setSaveMessage('Failed to save filters');
       setTimeout(() => setSaveMessage(null), 5000);
     } finally {

--- a/web/src/components/analytics/SankeyDiagram.tsx
+++ b/web/src/components/analytics/SankeyDiagram.tsx
@@ -1,0 +1,97 @@
+// Sankey Diagram for Application Funnel
+
+'use client';
+
+import { useMemo } from 'react';
+
+type SankeyNode = {
+  name: string;
+  value: number;
+  color: string;
+};
+
+type SankeyLink = {
+  source: string;
+  target: string;
+  value: number;
+  color: string;
+};
+
+type SankeyDiagramProps = {
+  nodes: SankeyNode[];
+  links: SankeyLink[];
+};
+
+export default function SankeyDiagram({ nodes, links }: SankeyDiagramProps) {
+  // Calculate total for normalization
+  const maxValue = useMemo(() => {
+    return Math.max(...nodes.map(n => n.value), 1);
+  }, [nodes]);
+
+  // Calculate node heights based on values
+  const nodeHeights = useMemo(() => {
+    return nodes.map(node => ({
+      ...node,
+      height: (node.value / maxValue) * 100, // percentage
+    }));
+  }, [nodes, maxValue]);
+
+  return (
+    <div className="w-full">
+      {/* Nodes */}
+      <div className="flex items-center justify-between gap-4 mb-8">
+        {nodeHeights.map((node, index) => (
+          <div key={index} className="flex-1 flex flex-col items-center gap-2">
+            <div className="text-xs font-medium text-center text-muted">
+              {node.name}
+            </div>
+            <div
+              className="w-full rounded transition-all duration-500"
+              style={{
+                backgroundColor: node.color,
+                height: `${Math.max(node.height, 20)}px`,
+                opacity: 0.8,
+              }}
+            />
+            <div className="text-sm font-semibold text-center">
+              {node.value}
+            </div>
+            <div className="text-xs text-muted text-center">
+              {((node.value / maxValue) * 100).toFixed(0)}%
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Flow visualization - simplified */}
+      <div className="space-y-3 mt-8">
+        <div className="text-xs text-muted font-semibold mb-2">Application Flow</div>
+        {links.map((link, index) => {
+          const percentage = (link.value / maxValue) * 100;
+          return (
+            <div key={index} className="flex items-center gap-3">
+              <div className="text-xs text-muted min-w-[120px]">
+                {link.source} → {link.target}
+              </div>
+              <div className="flex-1 bg-white/5 rounded-full h-4 overflow-hidden">
+                <div
+                  className="h-full rounded-full transition-all duration-500"
+                  style={{
+                    width: `${percentage}%`,
+                    backgroundColor: link.color,
+                  }}
+                />
+              </div>
+              <div className="text-sm font-medium min-w-[60px] text-right">
+                {link.value}
+              </div>
+              <div className="text-xs text-muted min-w-[45px] text-right">
+                {percentage.toFixed(0)}%
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
… tabs

- Add backend API endpoints for saving/loading default filter preferences
- Implement filter persistence using MongoDB for both default and snapshot views
- Create Sankey diagram component for application funnel visualization
- Move application funnel to Overview tab with new Sankey diagram
- Move Monthly Application Volume to Applications tab
- Move performance metrics (Avg Response Time, Interview Rate, Success Rate, Conversion Metrics) to Applications tab
- Remove Performance tab from navigation
- Enable Analytics button on home page
- Filters are now saved to backend and restored on page load