### PR TITLE
Fix hydration mismatch errors and auto-load snapshots in analytics

### DIFF
--- a/frontend/src/app/(protected)/analytics/page.tsx
+++ b/frontend/src/app/(protected)/analytics/page.tsx
@@ -203,6 +203,23 @@ function AnalyticsPageInner() {
     init();
   }, []);
 
+  // Auto-load first snapshot if no current data
+  useEffect(() => {
+    const autoLoadSnapshot = async () => {
+      // Only auto-load if:
+      // 1. We're not already viewing a snapshot
+      // 2. There's no current data
+      // 3. We have snapshots available
+      // 4. Data has finished loading
+      if (!viewingSnapshot && (!rawData || rawData.length === 0) && !isLoading && snapshots.length > 0) {
+        // Load the most recent snapshot (first in the list)
+        await handleViewSnapshot(snapshots[0].id);
+      }
+    };
+
+    autoLoadSnapshot();
+  }, [rawData, isLoading, snapshots, viewingSnapshot]);
+
   // View snapshot
   const handleViewSnapshot = async (snapshotId: string) => {
     try {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -25,8 +25,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+    <html lang="en" suppressHydrationWarning>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`} suppressHydrationWarning>
         <div className="min-h-screen flex flex-col">
           <header className="sticky top-0 z-40 border-b border-default backdrop-blur supports-[backdrop-filter]:bg-black/40">
             <nav className="container-px mx-auto flex h-16 items-center justify-between">
@@ -38,7 +38,7 @@ export default function RootLayout({
           </header>
           <main className="container-px mx-auto w-full max-w-6xl flex-1 py-8">{children}</main>
           <footer className="container-px mx-auto w-full max-w-6xl py-8 text-xs text-muted">
-            <p>© {new Date().getFullYear()} KapLabs Jobs</p>
+            <p suppressHydrationWarning>© {new Date().getFullYear()} KapLabs Jobs</p>
           </footer>
         </div>
       </body>


### PR DESCRIPTION
- Add suppressHydrationWarning to html and body tags to prevent hydration mismatch errors caused by browser extensions injecting attributes
- Add suppressHydrationWarning to footer paragraph using Date.now()
- Implement auto-loading of first snapshot when no current analytics data is available, providing users with historical data view by default
- Improve user experience by showing meaningful data instead of empty state when snapshots exist